### PR TITLE
Eliminación codigo no indespensable en URLs backend

### DIFF
--- a/Productos/Producto/urls.py
+++ b/Productos/Producto/urls.py
@@ -9,12 +9,8 @@ from Productos.Producto.views import register
 urlpatterns = [
     # Rutas de autenticación
     path('login/', auth_views.LoginView.as_view(template_name='registration/login.html'), name='login'),
-    path('logout/', auth_views.LogoutView.as_view(next_page='productos'), name='exit'), # Redirige a la home pública al salir
-    #path('register/', auth_views.LoginView.as_view(template_name='registration/register.html'), name='register'),
-    #path('register/', auth_views.LoginView.as_view(template_name='registration/register.html'), name='register'),
-    
+    path('logout/', auth_views.LogoutView.as_view(next_page='productos'), name='exit'), # Redirige a la home pública al salir 
     path('register/', views.register, name='register'),
-    #path('logout/', exit, name='exit'),
     
     #Rutas Publicas
     path('', views.inicio),
@@ -24,17 +20,10 @@ urlpatterns = [
     path('nosotros/', views.nosotros, name='nosotros'),
     path('productos/', views.productos, name='productos'),
     
-    # Rutas del dashboard de productos (protegidas)
-    #path('registrarProducto/', views.registrarProducto),
-    #path('home/edicionProducto/<codigo>', views.edicionProducto),
-    #path('home/editarProducto/', views.editarProducto),
-    #path('home/eliminarProducto/<codigo>', views.eliminarProducto),
-    
+    #Rutas Privadas
     path('productos/registrarProducto/', views.registrarProducto, name='registrarProducto'),
     path('edicionProducto/<str:codigo>/', views.edicionProducto, name='edicionProducto'),
     path('editarProducto/', views.registrarProducto, name='gestionProducto'),
-     # Asegúrate que el tipo de 'codigo' coincida con tu modelo
-    #path('gestionProducto/', views.editarProducto, name='edicionProducto'),
     path('eliminarProducto/<str:codigo>/', views.eliminarProducto, name='eliminarProducto'), # Asegúrate que el tipo de 'codigo' coincida
     
 ]


### PR DESCRIPTION
OK

## Summary by Sourcery

Clean up the backend URL configuration by removing obsolete commented routes and streamline authentication and product management paths.

Enhancements:
- Strip out redundant and commented-out URL patterns to simplify urls.py.
- Consolidate the registration route to a single views.register entry and preserve logout redirection.
- Standardize private product management paths with clear endpoints and naming for registrarProducto, edicionProducto/<str:codigo>, gestionProducto, and eliminarProducto/<str:codigo>.